### PR TITLE
use https instead of defaulting to http and add #sequence

### DIFF
--- a/lib/mixmax.rb
+++ b/lib/mixmax.rb
@@ -8,16 +8,20 @@ class Mixmax
     @headers = { "X-API-Token" => api_key, "Content-Type" => "application/json"}
   end
 
-  base_uri "api.mixmax.com"
+  base_uri "https://api.mixmax.com"
 
   def sequences
     self.class.get("/v1/sequences", headers: @headers).parsed_response["results"]
   end
 
+  def sequence(id)
+    self.class.get("/v1/sequences/#{id}", headers: @headers).parsed_response
+  end
+
   def sequence_recipients(id)
     self.class.get("/v1/sequences/#{id}/recipients", headers: @headers)
   end
-  
+
   def add_to_sequence(id, recipients)
     self.class.post("/v1/sequences/#{id}/recipients", headers: @headers, body: recipients)
   end


### PR DESCRIPTION
## Description
The [Mixmax `POST` method for `sequences/:id/recipients`](https://developer.mixmax.com/reference#sequencessequenceidrecipients) wasn't working because it wasn't done over `https` (it defaulted to `http` instead). This fixes that.

It also adds a `#show`-like functionality (i.e. `READ` for a single record) for sequences (i.e. `GET` `/sequences/:id`).